### PR TITLE
docs: Translate README.md to Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,63 @@
-# Cartesian Number Mapper in C
+# Mapeador Cartesiano de Números em C
 
-## Overview
+## Visão Geral
 
-This project provides a C program (`mapper.c`) that maps large unsigned integer numbers to 2D Cartesian coordinates (x, y). The mapping is based on a geometric interpretation where each number corresponds to a polar vector, which is then converted to Cartesian coordinates. This approach utilizes a predefined angular spiral and pre-calculated trigonometric values to avoid external mathematical libraries.
+Este projeto fornece um programa em C (`mapper.c`) que mapeia números inteiros grandes (unsigned long) para coordenadas Cartesianas 2D (x, y). O mapeamento é baseado em uma interpretação geométrica onde cada número corresponde a um vetor polar, que é então convertido para coordenadas Cartesianas. Esta abordagem utiliza uma espiral angular predefinida e valores trigonométricos pré-calculados para evitar bibliotecas matemáticas externas.
 
-The core logic is encapsulated in the `map_to_cartesian` function within `mapper.c`.
+A lógica principal está encapsulada na função `map_to_cartesian` dentro de `mapper.c`.
 
-## Mathematical Process
+## Processo Matemático
 
-The mapping from an input number to Cartesian coordinates follows these steps:
+O mapeamento de um número de entrada para coordenadas Cartesianas segue estes passos:
 
-1.  **Input Number (`N`)**: An `unsigned long` integer.
+1.  **Número de Entrada (`N`)**: Um inteiro `unsigned long`.
 
-2.  **Angular Component (Theta Determination)**:
-    *   The system uses a spiral of 40 discrete angular vectors, each separated by 9 degrees (40 * 9° = 360°).
-    *   The specific vector for the input number `N` is determined by its remainder when divided by 40:
-        `theta_index = N % 40`
-    *   This `theta_index` is then used to look up pre-calculated sine and cosine values. The actual angle in degrees would be `theta = theta_index * 9`.
+2.  **Componente Angular (Determinação de Theta)**:
+    *   O sistema usa uma espiral de 40 vetores angulares discretos, cada um separado por 9 graus (40 * 9° = 360°).
+    *   O vetor específico para o número de entrada `N` é determinado pelo seu resto quando dividido por 40:
+        `indice_theta = N % 40`
+    *   Este `indice_theta` é então usado para consultar valores de seno e cosseno pré-calculados. O ângulo real em graus seria `theta = indice_theta * 9`.
 
-3.  **Radial Component (Radius Determination)**:
-    *   The magnitude (or radius `r`) of the vector is determined by the integer quotient of the input number `N` divided by 40:
-        `radius = N / 40`
+3.  **Componente Radial (Determinação do Raio)**:
+    *   A magnitude (ou raio `r`) do vetor é determinada pelo quociente inteiro do número de entrada `N` dividido por 40:
+        `raio = N / 40`
 
-4.  **Coordinate Calculation**:
-    *   With the `theta_index` and `radius`, the Cartesian coordinates (x, y) are calculated using:
-        *   `x_coordinate = radius * cos_table[theta_index]`
-        *   `y_coordinate = radius * sin_table[theta_index]`
-    *   `cos_table` and `sin_table` are pre-calculated arrays storing the cosine and sine values for each of the 40 angles (0°, 9°, 18°, ..., 351°).
+4.  **Cálculo das Coordenadas**:
+    *   Com o `indice_theta` e `raio`, as coordenadas Cartesianas (x, y) são calculadas usando:
+        *   `coordenada_x = raio * tabela_cos[indice_theta]`
+        *   `coordenada_y = raio * tabela_sin[indice_theta]`
+    *   `tabela_cos` e `tabela_sin` são arrays pré-calculados que armazenam os valores de cosseno e seno para cada um dos 40 ângulos (0°, 9°, 18°, ..., 351°).
 
-## Implementation Details
+## Detalhes da Implementação
 
-*   **Language**: C (C99 standard assumed for `unsigned long` and `float` types).
-*   **Input Number Type**: `unsigned long`.
-*   **Trigonometric Values**: `float` type, stored in `sin_table` and `cos_table`.
-*   **Output Coordinates**: `float` type.
-*   **Dependencies**: Standard C library (`stdio.h` for printing). No external math libraries (like `math.h` for `sin`/`cos` functions at runtime) are used for the core conversion; trigonometric values are from tables. The `-lm` flag during compilation is good practice if `math.h` functions were to be added later but is not strictly needed for the current table-based `sin`/`cos` lookup.
+*   **Linguagem**: C (padrão C99 assumido para os tipos `unsigned long` e `float`).
+*   **Tipo do Número de Entrada**: `unsigned long`.
+*   **Valores Trigonométricos**: Tipo `float`, armazenados em `tabela_sin` e `tabela_cos`.
+*   **Coordenadas de Saída**: Tipo `float`.
+*   **Dependências**: Biblioteca padrão C (`stdio.h` para impressão). Nenhuma biblioteca matemática externa (como `math.h` para funções `sin`/`cos` em tempo de execução) é usada para a conversão principal; os valores trigonométricos vêm de tabelas. A flag `-lm` durante a compilação é uma boa prática caso funções de `math.h` sejam adicionadas posteriormente, mas não é estritamente necessária para a atual consulta de `sin`/`cos` baseada em tabelas.
 
-## Compilation
+## Compilação
 
-To compile the `mapper.c` program, use a C compiler like GCC:
+Para compilar o programa `mapper.c`, use um compilador C como o GCC:
 
 ```bash
 gcc mapper.c -o mapper -lm
 ```
-(The `-lm` links the math library, which isn't strictly necessary for the current version using only tables but is harmless.)
+(O `-lm` vincula a biblioteca matemática, o que não é estritamente necessário para a versão atual que usa apenas tabelas, mas é inofensivo.)
 
-## Execution
+## Execução
 
-After successful compilation, run the executable:
+Após a compilação bem-sucedida, execute o programa:
 
 ```bash
 ./mapper
 ```
 
-The program will use a hardcoded example number (`123456789`) and print the mapping details to the console.
+O programa usará um número de exemplo codificado no programa (`123456789`) e imprimirá os detalhes do mapeamento no console.
 
-## Example Output
+## Exemplo de Saída
 
-Running the `mapper` executable will produce output similar to the following (exact floating-point precision may vary slightly based on system/compiler):
+A execução do `mapper` produzirá uma saída similar à seguinte (a precisão exata do ponto flutuante pode variar ligeiramente dependendo do sistema/compilador):
 
 ```
 Input Number: 123456789
@@ -69,4 +69,4 @@ Calculated X Coordinate: -482822.34375000
 Calculated Y Coordinate: -3048420.25000000
 ```
 
-This output shows the input number, its corresponding theta index and angle, the calculated radius, the sine/cosine values retrieved from the tables for that index, and the final computed X and Y Cartesian coordinates.
+Esta saída mostra o número de entrada, seu correspondente índice theta e ângulo, o raio calculado, os valores de seno/cosseno recuperados das tabelas para esse índice, e as coordenadas Cartesianas X e Y finais computadas.


### PR DESCRIPTION
The README.md file content has been translated from English to Portuguese to better serve Portuguese-speaking users, as per your request.

All sections, including the overview, mathematical explanation, implementation details, compilation/execution instructions, and the example output, are now in Portuguese.